### PR TITLE
feat: implement amp roar

### DIFF
--- a/const/chains.ts
+++ b/const/chains.ts
@@ -93,10 +93,10 @@ export const SUPPORTED_CHAINS: { [key: string]: Chain } = {
     },
     icon: "https://raw.githubusercontent.com/terra-money/station-assets/main/img/chains/Terra.svg",
     allianceCoins: {
-      "ibc/0E90026619DD296AD4EF9546396F292B465BAB6B5BE00ABD6162AA1CE8E68098": {
-        name: "rSWTH",
-        priceKey: "rSWTH",
-        icon: "https://raw.githubusercontent.com/terra-money/station-assets/main/img/coins/rSWTH.svg",
+      "factory/terra1vklefn7n6cchn0u962w3gaszr4vf52wjvd4y95t2sydwpmpdtszsqvk9wy/ampROAR": {
+        name: "ampRoar",
+        priceKey: "AMPROAR",
+        icon: "https://raw.githubusercontent.com/terra-money/station-assets/main/img/coins/ampROAR.png",
       },
       "ibc/B3F639855EE7478750CC8F82072307ED6E131A8EFF20345E1D136B50C4E5EC36": {
         name: "ampWhale",
@@ -107,6 +107,11 @@ export const SUPPORTED_CHAINS: { [key: string]: Chain } = {
         name: "bWhale",
         priceKey: "BWHALE",
         icon: "https://raw.githubusercontent.com/terra-money/station-assets/main/img/coins/bWHALE.png",
+      },
+      "ibc/0E90026619DD296AD4EF9546396F292B465BAB6B5BE00ABD6162AA1CE8E68098": {
+        name: "rSWTH",
+        priceKey: "rSWTH",
+        icon: "https://raw.githubusercontent.com/terra-money/station-assets/main/img/coins/rSWTH.svg",
       },
     },
   }),

--- a/models/Prices.ts
+++ b/models/Prices.ts
@@ -1,3 +1,5 @@
+import { LCD } from "./LCDConfig"
+
 export interface TerraPriceServerResponse {
     created_at: string,
     prices: Array<{
@@ -15,15 +17,29 @@ export interface Prices {
     }
 }
 
+// Used to calculate the price of ampROAR
+interface ErisLSDResponse {
+    exchange_rate: string;
+
+    // total_ustake: string;
+    // total_utoken: string;
+    // unlocked_coins: any[];
+    // unbonding: string;
+    // available: string;
+    // tvl_utoken: string;
+}
+
 // Query all prices from the different servers
 // available and merge them into a single object
 export const QueryAndMergePrices = async (): Promise<Prices> => {
     const pricesRes = await Promise.all([
         fetch("https://price.api.tfm.com/tokens/?limit=1500"),
-        fetch("https://pisco-price-server.terra.dev/latest")
+        fetch("https://pisco-price-server.terra.dev/latest"),
+        // ampRoar Smart Contract
+        LCD.wasm.contractQuery("terra1vklefn7n6cchn0u962w3gaszr4vf52wjvd4y95t2sydwpmpdtszsqvk9wy", { "state": {} }),
     ]);
     const [tfmPrices, terraOraclePrices]: [Prices, TerraPriceServerResponse] = await Promise.all([pricesRes[0].json(), pricesRes[1].json()]);
-    const prices = terraOraclePrices.prices.reduce((acc, price) => {
+    let prices = terraOraclePrices.prices.reduce((acc, price) => {
         acc[price.denom] = {
             chain: "",
             change24h: 0,
@@ -33,5 +49,24 @@ export const QueryAndMergePrices = async (): Promise<Prices> => {
         return acc
     }, {} as Prices)
 
+    // Quick fix for the AMPROAR price because 
+    // there is no way to recover the price from 
+    // any of the different Price Providers in
+    // the oracle feeder.
+    prices = parseRoarPrice(prices, pricesRes[2] as ErisLSDResponse);
+    console.log(prices)
     return { ...tfmPrices, ...prices }
+}
+
+const parseRoarPrice = (prices: Prices, roarRes: ErisLSDResponse): Prices => {
+    let roarPrice = prices["ROAR"]?.usd ?? 0;
+
+    prices["AMPROAR"] = {
+        chain: "",
+        change24h: 0,
+        contract_addr: "",
+        usd: parseFloat(roarRes.exchange_rate) * roarPrice,
+    }
+
+    return prices;
 }


### PR DESCRIPTION
Given ROAR price from Coingecko and a cached request to the prices it will calculate the stats of the Alliance.
- PR for Oracle Feeder: https://github.com/terra-money/oracle-feeder-go/pull/104
- PR for development Oracle Feeder: https://github.com/terra-money/oracle-feeder-go/pull/105

This PR is an anti-pattern but it's better to do this anti-pattern and fix it when we have more price sources for ampROAR that does not break the oracle-feeder design pattern